### PR TITLE
update navbar color in css

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -136,8 +136,7 @@ a:hover { color: #007eb2; }
 
 .nav>li {
     position: relative;
-    display: block;
-    background-color: #054698;
+    color: #054698;
 }
 
 .navbar-default .navbar-nav>li>a:focus, .navbar-default .navbar-nav>li>a:hover {


### PR DESCRIPTION
Currently, the sidebar uses a dark blue color block with black text when the mouse hovers over a navbar link, which is visually difficult to see (sorry, I implemented this a while ago). You can observe this in the "on this page" section on the right side of [this FIMS vignette](https://noaa-fims.github.io/FIMS/articles/fims-path-maturity.html). This becomes more pronounced when I was developing documentation tabsets for FIMS.

This PR changes the sidebar displays and uses a light blue block when the mouse hovers over a navbar link. To reproduce a FIMS example locally, you can:

- [clone the latest FIMS](https://github.com/NOAA-FIMS/FIMS) and go to the `post-documentation-table` branch 
- run `pkgdown::build_site()` locally and preview the site using `pkgdown::preview_site(`)
- On FIMS site, navigate to `Articles` -> `Fisheries Integrated Modeling System (FIMS) Documentation` to view a tab or `FIMS Path: Maturity` to view a sidebar

Let me know if you have any suggestions or questions!
