### PR TITLE
Edit authors, add build pkgdown

### DIFF
--- a/.github/workflows/call-build-pkgdown.yml
+++ b/.github/workflows/call-build-pkgdown.yml
@@ -1,0 +1,14 @@
+# Checks that the pkgdown site builds for a repository.
+# this assumes pkgdown is already set up.
+name: call-build-pkgdown
+# on specifies the build triggers. See more info at https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+on:
+# this workflow runs on pushes to main or master or any time a new tag is pushed
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/build-pkgdown.yml@main

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,12 +2,12 @@ Package: nmfspalette
 Title: A Color Palette for NOAA Fisheries
 Version: 3.0.0.000
 Authors@R: c(
-    person(c("Christine", "christine.stawitz@noaa.gov"), "Stawitz", role = c("aut", "cre")),
-    person(c("Bai", "Li"), "bai.li@noaa.gov", role = "aut"),
-    person(c("Kathryn", "Doering"), "kathryn.doering@noaa.gov", role = "aut"),
-    person(c("Sophie", "sophie.breitbart@noaa.gov"), "Breitbart", role = "ctb"),
-    person(c("Steve", "steven.saul@noaa.gov"), "Saul", role = "ctb"),
-    person(c("Sam", "samantha.schiano@noaa.gov"), "Schiano", role = "ctb")
+    person(given = "Christine", family = "Stawitz", email = "christine.stawitz@noaa.gov", role = c("aut", "cre")),
+    person(given = "Bai", family = "Li", email = "bai.li@noaa.gov", role = "aut"),
+    person(given = "Kathryn", family = "Doering", email = "kathryn.doering@noaa.gov", role = "ctb"),
+    person(given = "Sophie", family = "Breitbart", email = "sophie.breitbart@noaa.gov", role = "ctb"),
+    person(given = "Steve", family = "Saul", email = "steven.saul@noaa.gov",  role = "ctb"),
+    person(given = "Sam", family = "Schiano", email ="samantha.schiano@noaa.gov", role = "ctb")
   )
 Description: This is a package that implements a color palette in line
     with the NOAA Fisheries Branding Guide.

--- a/man/nmfspalette.Rd
+++ b/man/nmfspalette.Rd
@@ -16,19 +16,19 @@ colors.
 }
 
 \author{
-\strong{Maintainer}: Christine christine.stawitz@noaa.gov Stawitz
+\strong{Maintainer}: Christine Stawitz \email{christine.stawitz@noaa.gov}
 
 Authors:
 \itemize{
-  \item Bai Li bai.li@noaa.gov
-  \item Kathryn Doering kathryn.doering@noaa.gov
+  \item Bai Li \email{bai.li@noaa.gov}
 }
 
 Other contributors:
 \itemize{
-  \item Sophie sophie.breitbart@noaa.gov Breitbart [contributor]
-  \item Steve steven.saul@noaa.gov Saul [contributor]
-  \item Sam samantha.schiano@noaa.gov Schiano [contributor]
+  \item Kathryn Doering \email{kathryn.doering@noaa.gov} [contributor]
+  \item Sophie Breitbart \email{sophie.breitbart@noaa.gov} [contributor]
+  \item Steve Saul \email{steven.saul@noaa.gov} [contributor]
+  \item Sam Schiano \email{samantha.schiano@noaa.gov} [contributor]
 }
 
 }


### PR DESCRIPTION
The pkgdown deployment on main was broken because the authors were not formatted correctly in the DESCRIPTION file. This PR helps remedy this issue by:
- fixing the author syntax (used the [function documentation for the person function](https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/person) and [example description file in R pkgs book](https://r-pkgs.org/description.html#the-description-file))
- Add a workflow that builds the pkgdown on Pull requests (or manually, if desired) to check that pkgdown can build before PRs are merged into main.